### PR TITLE
fix: runtime loading of api key

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -13,4 +13,4 @@ config :loadfest,
   logflare_endpoint_stag: "https://api.logflarestaging.com/logs",
   endpoint: "https://test.logflarestaging.com"
 
-import_config("#{Mix.env()}.exs")
+import_config("#{config_env()}.exs")

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -3,4 +3,4 @@ import Config
 config :loadfest,
   source_names: ["loadfest.test.0", "loadfest.test.1"]
 
-import_config("#{Mix.env()}.secret.exs")
+import_config "dev.secret.exs"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,4 +1,6 @@
 import Config
 
-config :loadfest,
-  api_key: System.get_env("LOGFLARE_PUBLIC_API_KEY")
+if System.get_env("LOGFLARE_PUBLIC_API_KEY") do
+  config :loadfest,
+    api_key: System.get_env("LOGFLARE_PUBLIC_API_KEY")
+end


### PR DESCRIPTION
Fixes a bug in the loading of api key at runtime, where value was always getting set to nil even if a dev.secret.exs existed.