### PR TITLE
feat:realistic payloads

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -5,4 +5,16 @@ config :loadfest, env: :dev
 config :loadfest,
   source_names: ["loadfest.test.0", "loadfest.test.1"]
 
+# Realistic payload sources — uncomment to use fixture-shaped payloads per source type.
+# Override at runtime with: LOADFEST_SOURCE_NAMES=loadfest.edge_log,loadfest.postgres
+# config :loadfest,
+#   source_names: [
+#     "loadfest.edge_log",
+#     "loadfest.postgres",
+#     "loadfest.auth_middleware",
+#     "loadfest.realtime_log",
+#     "loadfest.storage",
+#     "loadfest.api_gateway_trace"
+#   ]
+
 import_config "dev.secret.exs"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -5,15 +5,7 @@ if System.get_env("LOGFLARE_PUBLIC_API_KEY") do
     api_key: System.get_env("LOGFLARE_PUBLIC_API_KEY")
 end
 
-if System.get_env("LOADFEST_SOURCE_MODE") == "realistic" do
-  default_sources =
-    "edge_log,postgres,auth_middleware,realtime_log,storage,api_gateway_trace"
-
-  prefixes =
-    System.get_env("LOADFEST_REALISTIC_SOURCES", default_sources)
-    |> String.split(",", trim: true)
-
-  config :loadfest,
-    source_mode: :realistic,
-    source_names: Enum.map(prefixes, &"loadfest.#{&1}")
+case System.get_env("LOADFEST_SOURCE_NAMES", "") |> String.split(",", trim: true) do
+  [] -> :ok
+  source_names -> config :loadfest, source_names: source_names
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -4,3 +4,16 @@ if System.get_env("LOGFLARE_PUBLIC_API_KEY") do
   config :loadfest,
     api_key: System.get_env("LOGFLARE_PUBLIC_API_KEY")
 end
+
+if System.get_env("LOADFEST_SOURCE_MODE") == "realistic" do
+  default_sources =
+    "edge_log,postgres,auth_middleware,realtime_log,storage,api_gateway_trace"
+
+  prefixes =
+    System.get_env("LOADFEST_REALISTIC_SOURCES", default_sources)
+    |> String.split(",", trim: true)
+
+  config :loadfest,
+    source_mode: :realistic,
+    source_names: Enum.map(prefixes, &"loadfest.#{&1}")
+end

--- a/lib/application.ex
+++ b/lib/application.ex
@@ -32,7 +32,12 @@ defmodule Loadfest.Application do
           ]
       end
 
-    if Application.get_env(:loadfest, :source_mode) == :realistic do
+    configured_sources = Application.get_env(:loadfest, :source_names, [])
+    fixture_sources = Loadfest.Fixtures.sources()
+
+    if Enum.any?(configured_sources, fn name ->
+         String.replace_prefix(name, "loadfest.", "") in fixture_sources
+       end) do
       Loadfest.Fixtures.load()
     end
 

--- a/lib/application.ex
+++ b/lib/application.ex
@@ -32,6 +32,10 @@ defmodule Loadfest.Application do
           ]
       end
 
+    if Application.get_env(:loadfest, :source_mode) == :realistic do
+      Loadfest.Fixtures.load()
+    end
+
     opts = [strategy: :one_for_one, name: Loadfest.Supervisor]
     Supervisor.start_link(children, opts)
   end

--- a/lib/fixtures.ex
+++ b/lib/fixtures.ex
@@ -2,6 +2,8 @@ defmodule Loadfest.Fixtures do
   @sources ~w(edge_log postgres auth_middleware realtime_log storage api_gateway_trace)
   @span_sources ~w(auth_middleware api_gateway_trace)
 
+  def sources, do: @sources
+
   def load do
     events =
       for source <- @sources, into: %{} do

--- a/lib/fixtures.ex
+++ b/lib/fixtures.ex
@@ -1,0 +1,50 @@
+defmodule Loadfest.Fixtures do
+  @sources ~w(edge_log postgres auth_middleware realtime_log storage api_gateway_trace)
+  @span_sources ~w(auth_middleware api_gateway_trace)
+
+  def load do
+    events =
+      for source <- @sources, into: %{} do
+        dir = Application.app_dir(:loadfest, "priv/fixtures/#{source}")
+
+        events =
+          dir
+          |> File.ls!()
+          |> Enum.filter(&String.ends_with?(&1, ".json"))
+          |> Enum.map(fn file -> Path.join(dir, file) |> File.read!() |> Jason.decode!() end)
+
+        {source, events}
+      end
+
+    :persistent_term.put({__MODULE__, :events}, events)
+    :ok
+  end
+
+  def random_event(source) do
+    :persistent_term.get({__MODULE__, :events})
+    |> Map.fetch!(source)
+    |> Enum.random()
+    |> stamp(source)
+  end
+
+  defp stamp(event, source) do
+    now_ns = System.os_time(:nanosecond)
+
+    event
+    |> Map.delete("id")
+    |> Map.delete("timestamp")
+    |> stamp_span(source, now_ns)
+  end
+
+  defp stamp_span(event, source, now_ns) when source in @span_sources do
+    event
+    |> Map.put("start_time", now_ns)
+    |> Map.put("end_time", now_ns)
+    |> Map.put("span_id", rand_hex(8))
+    |> Map.put("trace_id", rand_hex(16))
+  end
+
+  defp stamp_span(event, _source, _now_iso), do: event
+
+  defp rand_hex(bytes), do: :crypto.strong_rand_bytes(bytes) |> Base.encode16(case: :lower)
+end

--- a/lib/pipeline.ex
+++ b/lib/pipeline.ex
@@ -3,7 +3,6 @@ defmodule Loadfest.Pipeline do
 
   alias Broadway.Message
   require Logger
-  @source_names Application.get_env(:loadfest, :source_names)
   @max_rps Application.get_env(:loadfest, :max_rps, 100_000)
   defmodule Producer do
     use GenStage
@@ -51,11 +50,22 @@ defmodule Loadfest.Pipeline do
   end
 
   def handle_message(_processor_name, message, _context) do
-    name = Enum.random(@source_names)
+    source_names = Application.get_env(:loadfest, :source_names)
+    name = Enum.random(source_names)
+
+    batch =
+      case Application.get_env(:loadfest, :source_mode) do
+        :realistic ->
+          prefix = String.replace_prefix(name, "loadfest.", "")
+          for _ <- 1..length(message.data), do: Loadfest.Fixtures.random_event(prefix)
+
+        _ ->
+          message.data
+      end
 
     body = %{
       source_name: name,
-      batch: message.data
+      batch: batch
     }
 
     rps = Loadfest.Counter.requests()

--- a/lib/pipeline.ex
+++ b/lib/pipeline.ex
@@ -4,6 +4,7 @@ defmodule Loadfest.Pipeline do
   alias Broadway.Message
   require Logger
   @max_rps Application.get_env(:loadfest, :max_rps, 100_000)
+  @valid_fixture_sources Loadfest.Fixtures.sources()
   defmodule Producer do
     use GenStage
 
@@ -49,18 +50,17 @@ defmodule Loadfest.Pipeline do
     )
   end
 
+  defp fixture_prefix("loadfest." <> suffix) when suffix in @valid_fixture_sources, do: suffix
+  defp fixture_prefix(_), do: nil
+
   def handle_message(_processor_name, message, _context) do
     source_names = Application.get_env(:loadfest, :source_names)
     name = Enum.random(source_names)
 
     batch =
-      case Application.get_env(:loadfest, :source_mode) do
-        :realistic ->
-          prefix = String.replace_prefix(name, "loadfest.", "")
-          for _ <- 1..length(message.data), do: Loadfest.Fixtures.random_event(prefix)
-
-        _ ->
-          message.data
+      case fixture_prefix(name) do
+        nil -> message.data
+        prefix -> for _ <- 1..length(message.data), do: Loadfest.Fixtures.random_event(prefix)
       end
 
     body = %{

--- a/priv/fixtures/api_gateway_trace/01.json
+++ b/priv/fixtures/api_gateway_trace/01.json
@@ -1,0 +1,42 @@
+{
+  "attributes": {
+    "_client_address": "1.2.3.4",
+    "_http_request_method": "POST",
+    "_http_route": "/functions/v1/*path",
+    "_http_status_code": 404,
+    "_network_peer_address": "1.2.3.4",
+    "_network_peer_port": 57785,
+    "_network_protocol_version": "1.1",
+    "_server_address": "supabase-api-gateway",
+    "_url_path": "/functions/v1/stripe-worker",
+    "_url_scheme": "https",
+    "_user_agent_original": "pg_net/0.19.5"
+  },
+  "end_time": 0,
+  "event_message": "POST /functions/v1/*path",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "metadata": {
+    "type": "span"
+  },
+  "project": "supabase-api-gateway",
+  "resource": {
+    "cloud": {
+      "region": "us-east-1"
+    },
+    "deployment": {
+      "environment": "staging"
+    },
+    "service": {
+      "name": "supabase-api-gateway",
+      "version": "1.0.0"
+    }
+  },
+  "scope": {
+    "name": "go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin",
+    "version": "0.61.0"
+  },
+  "span_id": "0000000000000000",
+  "start_time": 0,
+  "timestamp": 0,
+  "trace_id": "00000000000000000000000000000000"
+}

--- a/priv/fixtures/api_gateway_trace/02.json
+++ b/priv/fixtures/api_gateway_trace/02.json
@@ -1,0 +1,35 @@
+{
+  "attributes": {
+    "method": "POST",
+    "path": "/functions/v1/stripe-worker",
+    "product": "functions",
+    "relative_path": "/stripe-worker"
+  },
+  "end_time": 0,
+  "event_message": "products.handle_request",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "metadata": {
+    "type": "span"
+  },
+  "parent_span_id": "0000000000000000",
+  "project": "supabase-api-gateway",
+  "resource": {
+    "cloud": {
+      "region": "us-east-1"
+    },
+    "deployment": {
+      "environment": "staging"
+    },
+    "service": {
+      "name": "supabase-api-gateway",
+      "version": "1.0.0"
+    }
+  },
+  "scope": {
+    "name": "supabase-api-gateway"
+  },
+  "span_id": "0000000000000000",
+  "start_time": 0,
+  "timestamp": 0,
+  "trace_id": "00000000000000000000000000000000"
+}

--- a/priv/fixtures/auth_middleware/01.json
+++ b/priv/fixtures/auth_middleware/01.json
@@ -1,0 +1,41 @@
+{
+  "attributes": {
+    "_http_client_ip": "1.2.3.4",
+    "_http_method": "POST",
+    "_http_request_content_length": 1724,
+    "_http_response_content_length": 68,
+    "_http_route": "/token",
+    "_http_scheme": "http",
+    "_http_status_code": 400,
+    "_http_target": "/token",
+    "_net_host_name": "auth.supabase.io",
+    "_net_protocol_version": "1.1",
+    "_net_sock_peer_addr": "1.2.3.4",
+    "_net_sock_peer_port": 36196,
+    "_user_agent_original": "stripped"
+  },
+  "end_time": 0,
+  "event_message": "api",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "metadata": {
+    "type": "span"
+  },
+  "resource": {
+    "gotrue": {
+      "version": "v2.184.0-rc.5"
+    },
+    "supabase": {
+      "read_replica": "false",
+      "region": "ap-southeast-1",
+      "stack": "prod"
+    }
+  },
+  "scope": {
+    "name": "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",
+    "version": "0.51.0"
+  },
+  "span_id": "0000000000000000",
+  "start_time": 0,
+  "timestamp": 0,
+  "trace_id": "00000000000000000000000000000000"
+}

--- a/priv/fixtures/auth_middleware/02.json
+++ b/priv/fixtures/auth_middleware/02.json
@@ -1,0 +1,27 @@
+{
+  "end_time": 0,
+  "event_message": "sql.rows",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "metadata": {
+    "type": "span"
+  },
+  "parent_span_id": "0000000000000000",
+  "resource": {
+    "gotrue": {
+      "version": "v2.184.0-rc.5"
+    },
+    "supabase": {
+      "read_replica": "false",
+      "region": "ap-southeast-1",
+      "stack": "prod"
+    }
+  },
+  "scope": {
+    "name": "github.com/XSAM/otelsql",
+    "version": "0.26.0"
+  },
+  "span_id": "0000000000000000",
+  "start_time": 0,
+  "timestamp": 0,
+  "trace_id": "00000000000000000000000000000000"
+}

--- a/priv/fixtures/edge_log/get_200.json
+++ b/priv/fixtures/edge_log/get_200.json
@@ -1,0 +1,115 @@
+{
+  "event_message": "GET | 200 | 1.2.3.4 | cf-ray-000000000000 | https://test-project.supabase.co/auth/v1/user | node",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "identifier": "test-project",
+  "metadata": {
+    "logflare_worker": { "worker_id": "4SSCY1" },
+    "request": {
+      "cf": {
+        "asOrganization": "Amazon Data Services UK",
+        "asn": 16509,
+        "botManagement": {
+          "corporateProxy": false,
+          "detectionIds": [152120193],
+          "ja3Hash": "4a228e363d473f3fb66a05d65eee612a",
+          "ja4": "t13d5311h1_ed6c8d7875f9_518fb456ca59",
+          "ja4Signals": {
+            "browser_ratio_1h": 0.020160317420959,
+            "cache_ratio_1h": 0.13584105670452,
+            "h2h3_ratio_1h": 2.0390612917254e-5,
+            "heuristic_ratio_1h": 0.01459008269012,
+            "ips_quantile_1h": 0.99970483779907,
+            "ips_rank_1h": 248,
+            "paths_rank_1h": 228,
+            "reqs_quantile_1h": 0.99975126981735,
+            "reqs_rank_1h": 209,
+            "uas_rank_1h": 332
+          },
+          "jsDetection": { "passed": false },
+          "score": 1,
+          "staticResource": false,
+          "verifiedBot": false
+        },
+        "city": "London",
+        "clientAcceptEncoding": "gzip, deflate, br",
+        "clientTcpRtt": 4,
+        "clientTrustScore": 1,
+        "colo": "LHR",
+        "continent": "EU",
+        "country": "GB",
+        "edgeRequestKeepAliveStatus": 1,
+        "httpProtocol": "HTTP/1.1",
+        "latitude": "51.50853",
+        "longitude": "-0.12574",
+        "postalCode": "E1W",
+        "region": "England",
+        "regionCode": "ENG",
+        "timezone": "Europe/London",
+        "tlsCipher": "AEAD-AES256-GCM-SHA384",
+        "tlsClientAuth": {
+          "certPresented": "0",
+          "certRevoked": "0",
+          "certVerified": "NONE"
+        },
+        "tlsVersion": "TLSv1.3"
+      },
+      "headers": {
+        "accept": "*/*",
+        "cf_connecting_ip": "1.2.3.4",
+        "cf_ipcountry": "GB",
+        "cf_ray": "cf-ray-000000000000",
+        "host": "test-project.supabase.co",
+        "user_agent": "node",
+        "x_client_info": "supabase-ssr/0.6.1 createServerClient",
+        "x_forwarded_proto": "https",
+        "x_real_ip": "1.2.3.4"
+      },
+      "host": "test-project.supabase.co",
+      "method": "GET",
+      "path": "/auth/v1/user",
+      "protocol": "https:",
+      "sb": {
+        "auth_user": "00000000-0000-0000-0000-000000000000",
+        "jwt": {
+          "apikey": {
+            "payload": {
+              "algorithm": "HS256",
+              "expires_at": 1992715906,
+              "issuer": "supabase",
+              "role": "anon",
+              "signature_prefix": "ai3ojK"
+            }
+          },
+          "authorization": {
+            "payload": {
+              "algorithm": "HS256",
+              "expires_at": 1766053504,
+              "issuer": "https://test-project.supabase.co/auth/v1",
+              "key_id": "/qG3f1CaDyROs8f5",
+              "role": "authenticated",
+              "session_id": "00000000-0000-0000-0000-000000000000",
+              "signature_prefix": "Zjoty1",
+              "subject": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        }
+      },
+      "url": "https://test-project.supabase.co/auth/v1/user"
+    },
+    "response": {
+      "headers": {
+        "cf_cache_status": "DYNAMIC",
+        "cf_ray": "cf-ray-000000000000",
+        "content_type": "application/json",
+        "sb_gateway_version": "1",
+        "sb_request_id": "00000000-0000-0000-0000-000000000000",
+        "transfer_encoding": "chunked"
+      },
+      "origin_time": 13,
+      "status_code": 200
+    }
+  },
+  "project": "test-project",
+  "request_id": "00000000-0000-0000-0000-000000000000",
+  "timestamp": 0
+}

--- a/priv/fixtures/edge_log/post_200.json
+++ b/priv/fixtures/edge_log/post_200.json
@@ -1,0 +1,114 @@
+{
+  "event_message": "POST | 200 | 1.2.3.4 | cf-ray-000000000000 | https://test-project.supabase.co/rest/v1/records?on_conflict=id | Deno/2.1.4 (variant; SupabaseEdgeRuntime/1.69.25)",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "identifier": "test-project",
+  "metadata": {
+    "logflare_worker": { "worker_id": "ZZ79SS" },
+    "request": {
+      "cf": {
+        "asOrganization": "Amazon Data Services Ireland Limited",
+        "asn": 16509,
+        "botManagement": {
+          "corporateProxy": false,
+          "ja3Hash": "a1465cad7ff59adb0e36ccd6339ba5db",
+          "ja4": "t23e1011h2_61a7dd8aa9b6_3fcd1a44f3e3",
+          "ja4Signals": {
+            "browser_ratio_1h": 0.0026498660445213,
+            "cache_ratio_1h": 0.038907047361135,
+            "h2h3_ratio_1h": 0.98994463682175,
+            "heuristic_ratio_1h": 0.22291173040867,
+            "ips_quantile_1h": 0.99974054098129,
+            "ips_rank_1h": 218,
+            "paths_rank_1h": 16,
+            "reqs_quantile_1h": 0.99995714426041,
+            "reqs_rank_1h": 36,
+            "uas_rank_1h": 294
+          },
+          "jsDetection": { "passed": false },
+          "score": 46,
+          "staticResource": false,
+          "verifiedBot": false
+        },
+        "city": "Dublin",
+        "clientAcceptEncoding": "gzip, br",
+        "clientTcpRtt": 4,
+        "clientTrustScore": 46,
+        "colo": "DUB",
+        "continent": "EU",
+        "country": "IE",
+        "edgeRequestKeepAliveStatus": 1,
+        "httpProtocol": "HTTP/2",
+        "latitude": "53.33326",
+        "longitude": "-6.24789",
+        "postalCode": "D02",
+        "region": "Leinster",
+        "regionCode": "L",
+        "timezone": "Europe/Dublin",
+        "tlsCipher": "AEAD-AES256-GCM-SHA384",
+        "tlsClientAuth": {
+          "certPresented": "0",
+          "certRevoked": "0",
+          "certVerified": "NONE"
+        },
+        "tlsVersion": "TLSv1.3"
+      },
+      "headers": {
+        "accept": "*/*",
+        "cf_connecting_ip": "1.2.3.4",
+        "cf_ipcountry": "IE",
+        "cf_ray": "cf-ray-000000000000",
+        "content_length": "18466",
+        "content_type": "application/json",
+        "host": "test-project.supabase.co",
+        "prefer": "resolution=merge-duplicates",
+        "user_agent": "Deno/2.1.4 (variant; SupabaseEdgeRuntime/1.69.25)",
+        "x_client_info": "supabase-js-deno/2.87.3",
+        "x_forwarded_proto": "https",
+        "x_real_ip": "1.2.3.4"
+      },
+      "host": "test-project.supabase.co",
+      "method": "POST",
+      "path": "/rest/v1/records",
+      "protocol": "https:",
+      "sb": {
+        "jwt": {
+          "apikey": {
+            "payload": {
+              "algorithm": "HS256",
+              "expires_at": 2079813626,
+              "issuer": "supabase",
+              "role": "service_role",
+              "signature_prefix": "xzZXVB"
+            }
+          },
+          "authorization": {
+            "payload": {
+              "algorithm": "HS256",
+              "expires_at": 2079813626,
+              "issuer": "supabase",
+              "role": "service_role",
+              "signature_prefix": "xzZXVB"
+            }
+          }
+        }
+      },
+      "search": "?on_conflict=id",
+      "url": "https://test-project.supabase.co/rest/v1/records?on_conflict=id"
+    },
+    "response": {
+      "headers": {
+        "cf_cache_status": "DYNAMIC",
+        "cf_ray": "cf-ray-000000000000",
+        "content_length": "0",
+        "content_range": "*/*",
+        "sb_gateway_version": "1",
+        "sb_request_id": "00000000-0000-0000-0000-000000000000"
+      },
+      "origin_time": 12,
+      "status_code": 200
+    }
+  },
+  "project": "test-project",
+  "request_id": "00000000-0000-0000-0000-000000000000",
+  "timestamp": 0
+}

--- a/priv/fixtures/edge_log/post_503.json
+++ b/priv/fixtures/edge_log/post_503.json
@@ -1,0 +1,112 @@
+{
+  "event_message": "POST | 503 | 1.2.3.4 | cf-ray-000000000000 | https://test-project.supabase.co/rest/v1/pings_general | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "identifier": "test-project",
+  "logflare_worker": { "worker_id": "GAG9IZ" },
+  "metadata": {
+    "logflare_worker": { "worker_id": "GAG9IZ" },
+    "request": {
+      "cf": {
+        "asOrganization": "Test ISP",
+        "asn": 52468,
+        "botManagement": {
+          "corporateProxy": false,
+          "ja3Hash": "36390100fa274f9fa152f770b71e3951",
+          "ja4": "q93daf12h3_e5b375c5d22e_5c06198af69e",
+          "ja4Signals": {
+            "browser_ratio_1h": 0.92763668298721,
+            "cache_ratio_1h": 0.30760100483894,
+            "h2h3_ratio_1h": 1.0,
+            "heuristic_ratio_1h": 0.0011678752489388,
+            "ips_quantile_1h": 0.99998807907104,
+            "ips_rank_1h": 10,
+            "paths_rank_1h": 8,
+            "reqs_quantile_1h": 0.99998807907104,
+            "reqs_rank_1h": 10,
+            "uas_rank_1h": 28
+          },
+          "jsDetection": { "passed": false },
+          "score": 39,
+          "staticResource": false,
+          "verifiedBot": false
+        },
+        "city": "Test City",
+        "clientAcceptEncoding": "gzip, deflate, br",
+        "clientTrustScore": 39,
+        "colo": "GYE",
+        "continent": "SA",
+        "country": "EC",
+        "edgeRequestKeepAliveStatus": 1,
+        "httpProtocol": "HTTP/3",
+        "latitude": "-2.19616",
+        "longitude": "-79.88622",
+        "region": "Test Region",
+        "regionCode": "T",
+        "timezone": "America/Test",
+        "tlsCipher": "AEAD-AES128-GCM-SHA256",
+        "tlsClientAuth": {
+          "certPresented": "0",
+          "certRevoked": "0",
+          "certVerified": "NONE"
+        },
+        "tlsVersion": "TLSv1.3"
+      },
+      "headers": {
+        "accept": "*/*",
+        "cf_connecting_ip": "1.2.3.4",
+        "cf_ipcountry": "EC",
+        "cf_ray": "cf-ray-000000000000",
+        "content_length": "116",
+        "content_type": "application/json",
+        "host": "test-project.supabase.co",
+        "prefer": "return=minimal",
+        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
+        "x_forwarded_proto": "https",
+        "x_real_ip": "1.2.3.4"
+      },
+      "host": "test-project.supabase.co",
+      "method": "POST",
+      "path": "/rest/v1/pings_general",
+      "protocol": "https:",
+      "sb": {
+        "jwt": {
+          "apikey": {
+            "payload": {
+              "algorithm": "HS256",
+              "expires_at": 2054973558,
+              "issuer": "supabase",
+              "role": "anon",
+              "signature_prefix": "MZc_X9"
+            }
+          },
+          "authorization": {
+            "payload": {
+              "algorithm": "HS256",
+              "expires_at": 2054973558,
+              "issuer": "supabase",
+              "role": "anon",
+              "signature_prefix": "MZc_X9"
+            }
+          }
+        }
+      },
+      "url": "https://test-project.supabase.co/rest/v1/pings_general"
+    },
+    "response": {
+      "headers": {
+        "cf_cache_status": "DYNAMIC",
+        "cf_ray": "cf-ray-000000000000",
+        "content_type": "text/plain",
+        "sb_gateway_version": "1",
+        "sb_request_id": "00000000-0000-0000-0000-000000000000",
+        "transfer_encoding": "chunked"
+      },
+      "origin_time": 56846,
+      "status_code": 503
+    }
+  },
+  "origin_time": 56846,
+  "project": "test-project",
+  "request_id": "00000000-0000-0000-0000-000000000000",
+  "timestamp": 0
+}

--- a/priv/fixtures/postgres/01.json
+++ b/priv/fixtures/postgres/01.json
@@ -1,0 +1,23 @@
+{
+  "event_message": "cron job 2 completed: 1 row",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "identifier": "test-project",
+  "metadata": {
+    "host": "db-test-project",
+    "parsed": {
+      "backend_type": "pg_cron launcher",
+      "error_severity": "LOG",
+      "process_id": 169902,
+      "query_id": -6400286027763998979,
+      "session_id": "a895f0b7.28fde",
+      "session_line_num": 374869,
+      "session_start_time": "2025-08-08 11:34:15 UTC",
+      "sql_state_code": "00000",
+      "timestamp": "2025-12-16 19:27:00.059 UTC",
+      "transaction_id": 0,
+      "virtual_transaction_id": "66/0"
+    }
+  },
+  "project": "test-project",
+  "timestamp": 0
+}

--- a/priv/fixtures/postgres/02.json
+++ b/priv/fixtures/postgres/02.json
@@ -1,0 +1,22 @@
+{
+  "event_message": "checkpoint complete: wrote 5 buffers (0.0%); 0 WAL file(s) added, 0 removed, 3 recycled; write=0.434 s, sync=0.010 s, total=0.544 s; sync files=6, longest=0.005 s, average=0.002 s; distance=49152 kB, estimate=49152 kB; lsn=163/60000080, redo lsn=163/60000028",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "identifier": "test-project",
+  "metadata": {
+    "host": "db-test-project",
+    "parsed": {
+      "backend_type": "checkpointer",
+      "error_severity": "LOG",
+      "process_id": 28136,
+      "query_id": 0,
+      "session_id": "f33b2c4a.a7e8",
+      "session_line_num": 73048,
+      "session_start_time": "2025-07-31 08:41:46 UTC",
+      "sql_state_code": "00000",
+      "timestamp": "2025-12-16 19:26:40.806 UTC",
+      "transaction_id": 0
+    }
+  },
+  "project": "test-project",
+  "timestamp": 0
+}

--- a/priv/fixtures/realtime_log/01.json
+++ b/priv/fixtures/realtime_log/01.json
@@ -1,0 +1,23 @@
+{
+  "event_message": "Starting Elixir.Realtime.RateCounter for: {:channel, :events, \"test-project\"}",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "metadata": {
+    "cluster": "main",
+    "context": {
+      "application": "realtime",
+      "domain": ["elixir"],
+      "file": "lib/realtime/rate_counter/rate_counter.ex",
+      "function": "init/1",
+      "gl": "<0.3288.0>",
+      "line": 148,
+      "mfa": ["Elixir.Realtime.RateCounter", "init", "1"],
+      "module": "Elixir.Realtime.RateCounter",
+      "pid": "<0.231090078.0>",
+      "time": 0,
+      "vm": { "node": "realtime@test-node" }
+    },
+    "level": "info",
+    "region": "eu-west-2"
+  },
+  "timestamp": 0
+}

--- a/priv/fixtures/storage/01.json
+++ b/priv/fixtures/storage/01.json
@@ -1,0 +1,24 @@
+{
+  "event_message": "[Lifecycle]: ObjectCreated:Post test-project/measurement/test-file.jpg",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "metadata": {
+    "context": {
+      "host": "ip-10-10-20-79.eu-central-1.compute.internal",
+      "pid": 1,
+      "service": "worker",
+      "type": "event"
+    },
+    "event": "ObjectCreated:Post",
+    "jodId": "00000000-0000-0000-0000-000000000000",
+    "level": "info",
+    "objectPath": "test-project/measurement/test-file.jpg",
+    "payload": "{\"name\":\"test-file.jpg\",\"reqId\":\"test-req-id\",\"tenant\":{\"ref\":\"test-project\",\"host\":\"test-project.supabase.co\"},\"bucketId\":\"measurement\",\"metadata\":{\"size\":58734,\"mimetype\":\"image/jpeg\",\"cacheControl\":\"max-age=3600\",\"httpStatusCode\":200},\"uploadType\":\"standard\"}",
+    "project": "test-project",
+    "region": "eu-central-1",
+    "reqId": "test-req-id",
+    "resources": ["/test-project/measurement/test-file.jpg"],
+    "tenantId": "test-project"
+  },
+  "project": "test-project",
+  "timestamp": 0
+}

--- a/test/fixtures_test.exs
+++ b/test/fixtures_test.exs
@@ -1,0 +1,100 @@
+defmodule Loadfest.FixturesTest do
+  use ExUnit.Case, async: false
+
+  alias Loadfest.Fixtures
+
+  setup_all do
+    Fixtures.load()
+    :ok
+  end
+
+  describe "sources/0" do
+    test "returns all expected fixture source names" do
+      assert Fixtures.sources() == ~w(edge_log postgres auth_middleware realtime_log storage api_gateway_trace)
+    end
+  end
+
+  describe "load/0" do
+    test "loads at least one event per source" do
+      for source <- Fixtures.sources() do
+        event = Fixtures.random_event(source)
+        assert is_map(event), "expected a map for source #{source}"
+      end
+    end
+  end
+
+  describe "random_event/1" do
+    test "does not include timestamp field (let logflare generate it)" do
+      event = Fixtures.random_event("edge_log")
+      refute Map.has_key?(event, "timestamp")
+    end
+
+    test "does not include id field (let logflare generate it)" do
+      event = Fixtures.random_event("edge_log")
+      refute Map.has_key?(event, "id")
+    end
+
+    test "preserves realistic payload shape for edge_log" do
+      event = Fixtures.random_event("edge_log")
+      assert get_in(event, ["metadata", "request", "cf", "httpProtocol"])
+      assert get_in(event, ["metadata", "response", "status_code"])
+      assert is_binary(event["event_message"])
+    end
+
+    test "preserves realistic payload shape for postgres" do
+      event = Fixtures.random_event("postgres")
+      assert get_in(event, ["metadata", "parsed", "error_severity"])
+      assert get_in(event, ["metadata", "host"])
+    end
+
+    test "stamps span fields for auth_middleware" do
+      before_ns = System.os_time(:nanosecond)
+      event = Fixtures.random_event("auth_middleware")
+      after_ns = System.os_time(:nanosecond)
+
+      assert event["start_time"] >= before_ns
+      assert event["start_time"] <= after_ns
+      assert event["end_time"] >= before_ns
+      assert String.length(event["span_id"]) == 16
+      assert String.length(event["trace_id"]) == 32
+    end
+
+    test "stamps span fields for api_gateway_trace" do
+      event = Fixtures.random_event("api_gateway_trace")
+      assert is_integer(event["start_time"])
+      assert is_integer(event["end_time"])
+      assert String.length(event["span_id"]) == 16
+      assert String.length(event["trace_id"]) == 32
+    end
+
+    test "does not stamp span fields for non-span sources" do
+      for source <- ~w(edge_log postgres realtime_log storage) do
+        event = Fixtures.random_event(source)
+        refute Map.has_key?(event, "span_id"), "#{source} should not have span_id"
+        refute Map.has_key?(event, "trace_id"), "#{source} should not have trace_id"
+      end
+    end
+
+    test "returns different events across calls (randomness)" do
+      events = for _ <- 1..20, do: Fixtures.random_event("edge_log")
+      unique_messages = events |> Enum.map(& &1["event_message"]) |> Enum.uniq()
+      # edge_log has 3 fixtures with different event_messages
+      assert length(unique_messages) > 1
+    end
+  end
+
+  describe "pipeline source name routing" do
+    test "fixture_prefix extracts known sources" do
+      # Tests the private logic via public behaviour: if source matches a fixture,
+      # random_event works; otherwise it would raise.
+      for source <- Fixtures.sources() do
+        assert %{} = Fixtures.random_event(source)
+      end
+    end
+
+    test "unknown source is not in fixtures sources list" do
+      refute "test.0" in Fixtures.sources()
+      refute "loadfest.test.0" in Fixtures.sources()
+    end
+  end
+end


### PR DESCRIPTION
Allow setting sources to realistic samples like the following.

loadfest.edge_log
loadfest.postgres
loadfest.auth_middleware
loadfest.realtime_log
loadfest.storage
 loadfest.api_gateway_trace

The can be set via the config or overridden via LOADFEST_SOURCE_NAMES env. 